### PR TITLE
Prevents page-top from breaking game in Issue #46

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -36,3 +36,14 @@ app.leaderboardView = new LeaderboardView({ model: app.leaderboard });
 $('#leaderboard div.container').append(app.leaderboardView.$el);
 
 new BattleList({ el: '.game-list' });
+
+$("a[data-href]").click(function(e) {
+    e.preventDefault();
+    switch ($(this).attr("data-href")) {
+        // Fixes #page-top from breaking game on refresh
+        case "#page-top":
+            $("html, body").animate({ scrollTop: 0 }, "slow");
+            break;
+    }
+    return false;
+});

--- a/public/dev.html
+++ b/public/dev.html
@@ -176,7 +176,7 @@
   </footer>
 
   <div class="scroll-top page-scroll visible-xs visible-sm">
-    <a class="btn btn-primary" href="#page-top">
+    <a class="btn btn-primary" data-href="#page-top">
       <i class="fa fa-chevron-up"></i>
     </a>
   </div>


### PR DESCRIPTION
In [#46](https://github.com/JSJitsu/ai-battle-website/issues/46), substitutes the page-top functionality to still scroll to the top, but not update the hash code (which is what is breaking the game)